### PR TITLE
Add basic unit tests for Epoch utilities

### DIFF
--- a/Simplified-Threat-Intelligence-Platform.Tests/Shared/EpochTests.cs
+++ b/Simplified-Threat-Intelligence-Platform.Tests/Shared/EpochTests.cs
@@ -1,0 +1,28 @@
+using System;
+using Simplified_Threat_Intelligence_Platform.Shared;
+using Xunit;
+
+namespace Simplified_Threat_Intelligence_Platform.Tests.Shared
+{
+    public class EpochTests
+    {
+        [Fact]
+        public void Now_Returns_Current_Seconds()
+        {
+            long before = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            long now = Epoch.Now();
+            long after = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            Assert.InRange(now, before, after);
+        }
+
+        [Fact]
+        public void DaysAgo_Computes_Correct_Offset()
+        {
+            const int days = 5;
+            long now = Epoch.Now();
+            long expected = now - days * 24L * 3600L;
+            long actual = Epoch.DaysAgo(days);
+            Assert.InRange(actual, expected - 1, expected + 1);
+        }
+    }
+}

--- a/Simplified-Threat-Intelligence-Platform.Tests/Simplified-Threat-Intelligence-Platform.Tests.csproj
+++ b/Simplified-Threat-Intelligence-Platform.Tests/Simplified-Threat-Intelligence-Platform.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Simplified_Threat_Intelligence_Platform.Tests</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Simplified-Threat-Intelligence-Platform.csproj" />
+  </ItemGroup>
+</Project>

--- a/Simplified-Threat-Intelligence-Platform.csproj
+++ b/Simplified-Threat-Intelligence-Platform.csproj
@@ -16,4 +16,9 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 
+  <!-- Exclude test sources from the main application build -->
+  <ItemGroup>
+    <Compile Remove="Simplified-Threat-Intelligence-Platform.Tests/**/*.cs" />
+  </ItemGroup>
+
 </Project>

--- a/Simplified-Threat-Intelligence-Platform.sln
+++ b/Simplified-Threat-Intelligence-Platform.sln
@@ -5,17 +5,23 @@ VisualStudioVersion = 17.14.36401.2 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Simplified-Threat-Intelligence-Platform", "Simplified-Threat-Intelligence-Platform.csproj", "{E5286C76-3B7E-4E61-AB9E-FF52F24E7836}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Simplified-Threat-Intelligence-Platform.Tests", "Simplified-Threat-Intelligence-Platform.Tests\Simplified-Threat-Intelligence-Platform.Tests.csproj", "{C79A2562-7AC4-44CE-861B-BEE4712316C7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E5286C76-3B7E-4E61-AB9E-FF52F24E7836}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E5286C76-3B7E-4E61-AB9E-FF52F24E7836}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E5286C76-3B7E-4E61-AB9E-FF52F24E7836}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E5286C76-3B7E-4E61-AB9E-FF52F24E7836}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {E5286C76-3B7E-4E61-AB9E-FF52F24E7836}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E5286C76-3B7E-4E61-AB9E-FF52F24E7836}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E5286C76-3B7E-4E61-AB9E-FF52F24E7836}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E5286C76-3B7E-4E61-AB9E-FF52F24E7836}.Release|Any CPU.Build.0 = Release|Any CPU
+                {C79A2562-7AC4-44CE-861B-BEE4712316C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {C79A2562-7AC4-44CE-861B-BEE4712316C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {C79A2562-7AC4-44CE-861B-BEE4712316C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {C79A2562-7AC4-44CE-861B-BEE4712316C7}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add xUnit test project for the solution
- create unit tests for Epoch utility methods
- exclude test sources from main project compilation

## Testing
- `dotnet test Simplified-Threat-Intelligence-Platform.sln`


------
https://chatgpt.com/codex/tasks/task_e_689b966ce0dc8324af33f07af8f858c0